### PR TITLE
Added logging function to donutGenerator.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ tools/donut_generator
 tools/oneline2donut/bin/Debug/net7.0
 tools/oneline2donut/obj
 tools/oneline2donut/example
+tools/donutGenerator.log

--- a/tools/README.md
+++ b/tools/README.md
@@ -87,6 +87,11 @@ Its output will consist of the donut and the amount of characters it contains.
 Character count: 300
 ```
 
+
+#### Logs
+
+Any donut generated will be added to `donutGenerator.log`, so it is recoverable even if the dimensions used to generate it are lost.
+
 ### `donutGenerator` errors
 
 #### Error 0: Not enough or too many arguments

--- a/tools/donutGenerator.py
+++ b/tools/donutGenerator.py
@@ -48,3 +48,12 @@ for y in range(outside_r):
     print()
 
 print(f"\nCharacter count: {character_amount}")
+
+# append generated donut to log
+with open("donutGenerator.log", 'a') as dgl:
+    dgl.write(f"Outer radius: {outside_r}, inner radius: {inside_r}, character count: {character_amount}")
+    for y in range(outside_r):
+        for x in range(outside_r * 2):
+            dgl.write(buffer[x + y * 2 * outside_r])
+        dgl.write("\n")
+    dgl.write("\n");


### PR DESCRIPTION
Donuts generated using `donutGenerator.py` will be added to `donutGenerator.log` so they can be used later even if the dimensions used to generate it are lost.